### PR TITLE
Med 69 implement UI for logout

### DIFF
--- a/apps/medon-fe/src/components/LogOut/index.tsx
+++ b/apps/medon-fe/src/components/LogOut/index.tsx
@@ -1,0 +1,37 @@
+import { useState } from 'react';
+import { Button, Modal } from 'antd';
+import { useTranslation } from 'react-i18next';
+
+export default function LogOut() {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const { t } = useTranslation();
+
+  const showModal = () => {
+    setIsModalOpen(true);
+  };
+
+  const handleOk = () => {
+    setIsModalOpen(false);
+  };
+
+  const handleCancel = () => {
+    setIsModalOpen(false);
+  };
+
+  return (
+    <>
+      <Button type="primary" onClick={showModal}>
+        Open Modal
+      </Button>
+      <Modal
+        title={t('logout.title')}
+        open={isModalOpen}
+        onOk={handleOk}
+        onCancel={handleCancel}
+      >
+        <span>{t('logout.description')}</span>
+      </Modal>
+    </>
+  );
+}

--- a/apps/medon-fe/src/pages/Login/index.tsx
+++ b/apps/medon-fe/src/pages/Login/index.tsx
@@ -1,14 +1,12 @@
 import Sidebar from 'components/Sidebar';
 
 import { Wrapper } from 'pages/Login/styles';
-import LoginComponent from 'components/LoginComponent/index';
-
-
+import LoginComponent from 'components/LoginComponent';
 
 export default function Login() {
   return (
     <Wrapper>
-      <LoginComponent  />
+      <LoginComponent />
       <Sidebar />
     </Wrapper>
   );

--- a/apps/medon-fe/src/translation/en/translation.json
+++ b/apps/medon-fe/src/translation/en/translation.json
@@ -177,5 +177,9 @@
       "linkTerm": "Terms and conditions",
       "linkPrivacy": "Privacy policy"
     }
+  },
+  "logout": {
+    "title": "Logout",
+    "description": "Are you sure you want to logout?"
   }
 }


### PR DESCRIPTION
# LogOut Modal for LogOut of the system

![logout modal](https://user-images.githubusercontent.com/94717377/232565966-6aa9ff95-4ffd-4c32-9210-124220912b1c.png)

## Features

- Component Logout

**PR checklist:**

**1.1 Common**
- [x] 1.1.2 no any, should be also added to eslint rules
- [x] 1.1.1 types for input and output params
- [x] 1.1.3 try/catch for any async function
- [x] 1.1.4 no magic numbers
- [x] 1.1.5 compare only with constants not with strings (instead of user === ‘admin’, better user === roles.admin)
- [x] 1.1.6 no ternary operator inside ternary operator (bad example: question ? first: second ? third: fourth)
- [x] 1.1.7 avoid similar types with duplicating by generics
- [x] 1.1.8 no console.log in pr
- [x] 1.1.9 .env file should be in .gitignore
- [x] 1.1.10 delete commented code if it's not part of documentation
- [x] 1.1.11 no links in the code, env links should be in env file (for example: server url),
- [x] constant links (for example default avatar URL) should be in constant file
- [x] 1.1.12 constants and function names should be lowercase.
- [x] 1.1.13 no dates format in the code (like "dd/MM/yyyy”), move it in global constant variable
- [x] 1.1.14 import rules. imports should come in a specific order: node modules, absolute path, relative path
- [x] 1.1.15 strings should be in the constant variable. Example: instead of ‘15 3 * * *’, const EACH_DAY_15h_15min = ‘15 3 * * *’

 **1.3 Frontend|Mobile**
- [x] 1.3.1 split component and logic (move logic to custom hook file)
- [x] 1.3.2 colors, font size, and font name should be in the theme or in the constants
- [x] 1.3.3 no text in the components, use i18n approach, even if you have only one language for now
- [x] 1.3.4 inline styles prohibited
- [x] 1.3.5 import should be absolute. instead of ../../../components/myComponent should be components/myComponent

