### PR TITLE
MED-97 fix link borders on reg confirmation page

### DIFF
--- a/apps/medon-fe/src/components/RegistrationConfirmation/styles.tsx
+++ b/apps/medon-fe/src/components/RegistrationConfirmation/styles.tsx
@@ -38,4 +38,5 @@ export const Btn = styled(Button)`
 export const BackBtn = styled(Btn)`
   background: ${(p) => p.theme.colors.black};
   width: 100%;
+  margin-bottom: 0;
 `;

--- a/apps/medon-fe/src/components/RegistrationConfirmation/styles.tsx
+++ b/apps/medon-fe/src/components/RegistrationConfirmation/styles.tsx
@@ -27,15 +27,15 @@ export const Text = styled.p`
 `;
 
 export const Btn = styled(Button)`
-  background: linear-gradient(90deg, #085dd7 -28.15%, #4d93f8 76.48%);
+  background: ${(p) => p.theme.colors.btnGradient};
   font-family: ${(p) => p.theme.fontFamily.sf_pro_text};
   color: ${(p) => p.theme.colors.white};
   min-width: 10rem;
   width: fit-content;
+  margin-bottom: 4rem;
 `;
 
 export const BackBtn = styled(Btn)`
   background: ${(p) => p.theme.colors.black};
   width: 100%;
-  margin-top: 4rem;
 `;


### PR DESCRIPTION
- Fix for border of "back to login" button on registration confirmation component

**PR checklist:**

**1.1 Common**
- [x] 1.1.2 no any, should be also added to eslint rules
- [x] 1.1.1 types for input and output params
- [x] 1.1.3 try/catch for any async function
- [x] 1.1.4 no magic numbers
- [x] 1.1.5 compare only with constants not with strings (instead of user === ‘admin’, better user === roles.admin)
- [x] 1.1.6 no ternary operator inside ternary operator (bad example: question ? first: second ? third: fourth)
- [x] 1.1.7 avoid similar types with duplicating by generics
- [x] 1.1.8 no console.log in pr
- [x] 1.1.9 .env file should be in .gitignore
- [x] 1.1.10 delete commented code if it's not part of documentation
- [x] 1.1.11 no links in the code, env links should be in env file (for example: server url),
- [x] constant links (for example default avatar URL) should be in constant file
- [x] 1.1.12 constants and function names should be lowercase.
- [x] 1.1.13 no dates format in the code (like "dd/MM/yyyy”), move it in global constant variable
- [x] 1.1.14 import rules. imports should come in a specific order: node modules, absolute path, relative path
- [x] 1.1.15 strings should be in the constant variable. Example: instead of ‘15 3 * * *’, const EACH_DAY_15h_15min = ‘15 3 * * *’

 **1.3 Frontend|Mobile**
- [x] 1.3.1 split component and logic (move logic to custom hook file)
- [x] 1.3.2 colors, font size, and font name should be in the theme or in the constants
- [x] 1.3.3 no text in the components, use i18n approach, even if you have only one language for now
- [x] 1.3.4 inline styles prohibited
- [x] 1.3.5 import should be absolute. instead of ../../../components/myComponent should be components/myComponent

