### PR TITLE
MED-197 change availability settings

### DIFF
--- a/apps/medon-fe/src/components/AvailabilityCalendar/hooks.tsx
+++ b/apps/medon-fe/src/components/AvailabilityCalendar/hooks.tsx
@@ -3,6 +3,7 @@ import { DateLocalizer, Event } from 'react-big-calendar';
 import { useTranslation } from 'react-i18next';
 import dayjs from 'dayjs';
 import isBetween from 'dayjs/plugin/isBetween';
+import isSameOrAfter from 'dayjs/plugin/isSameOrAfter';
 import timezone from 'dayjs/plugin/timezone';
 import utc from 'dayjs/plugin/utc';
 import { useForm } from 'react-hook-form';
@@ -32,6 +33,7 @@ import { checkDates, convertSlotToArray, joinConsecutiveDates } from './utils';
 dayjs.extend(isBetween);
 dayjs.extend(utc);
 dayjs.extend(timezone);
+dayjs.extend(isSameOrAfter);
 
 export function useCalendar() {
   const { t } = useTranslation();
@@ -106,7 +108,7 @@ export function useCalendar() {
   const handleSelectDay = useCallback(
     (event: Event) => {
       setEditIndex(null);
-      if (!dayjs(event.start).isAfter(dayjs())) {
+      if (!dayjs(event.start).isSameOrAfter(dayjs(), 'day')) {
         toast.warning(t('availability.badDate'), toastConfig);
         setSelectedDay(undefined);
       } else {
@@ -120,6 +122,12 @@ export function useCalendar() {
 
   const handleSelectEvent = useCallback(
     (event: Event) => {
+      if (dayjs(event.start).isBefore(dayjs())) {
+        setSelectedDay(undefined);
+
+        return;
+      }
+
       const index = timeSlots.findIndex(
         (object) =>
           dayjs(object.start).isSame(event.start) &&
@@ -147,6 +155,19 @@ export function useCalendar() {
         timeSlots[editIndex] as CalendarSlot
       ).map((e) => ({ startTime: e.startTime, endTime: e.endTime }));
 
+      const startTimes = arrayToRemove.map((e) => dayjs(e.startTime).valueOf());
+
+      const appointmentAlreadySet = availabilityResponse?.data?.filter(
+        (e) =>
+          startTimes.includes(dayjs(e.startTime).valueOf()) && !e.isAvailable
+      );
+
+      if (appointmentAlreadySet?.length) {
+        toast.error(t('availability.timeUsed'), toastConfig);
+
+        return;
+      }
+
       try {
         await removeSlot({ dto: arrayToRemove, timezone: tZone });
         setSelectedDay(undefined);
@@ -158,6 +179,12 @@ export function useCalendar() {
   };
 
   const handleSubmitEvent = async (data: SelectHours) => {
+    if (dayjs(selectedDay).hour(data.start).minute(0).isBefore(dayjs())) {
+      toast.error(t('availability.badTime'), toastConfig);
+
+      return;
+    }
+
     const title = `${dayjs()
       .hour(data.start)
       .minute(0)
@@ -202,6 +229,18 @@ export function useCalendar() {
             endTime: e.endTime,
           }))
         : [];
+
+    const startTimes = arrayToRemove.map((e) => dayjs(e.startTime).valueOf());
+
+    const appointmentAlreadySet = availabilityResponse?.data?.filter(
+      (e) => startTimes.includes(dayjs(e.startTime).valueOf()) && !e.isAvailable
+    );
+
+    if (appointmentAlreadySet?.length) {
+      toast.error(t('availability.timeUsed'), toastConfig);
+
+      return;
+    }
 
     const title = `${dayjs()
       .hour(data.start)

--- a/apps/medon-fe/src/components/AvailabilityCalendar/hooks.tsx
+++ b/apps/medon-fe/src/components/AvailabilityCalendar/hooks.tsx
@@ -163,7 +163,7 @@ export function useCalendar() {
       );
 
       if (appointmentAlreadySet?.length) {
-        toast.error(t('availability.timeUsed'), toastConfig);
+        toast.error(t('availability.appointmentSet'), toastConfig);
 
         return;
       }
@@ -237,7 +237,7 @@ export function useCalendar() {
     );
 
     if (appointmentAlreadySet?.length) {
-      toast.error(t('availability.timeUsed'), toastConfig);
+      toast.error(t('availability.appointmentSet'), toastConfig);
 
       return;
     }

--- a/apps/medon-fe/src/translation/en/translation.json
+++ b/apps/medon-fe/src/translation/en/translation.json
@@ -421,6 +421,7 @@
     "message": "Select day or availability slot to start editing",
     "timeUsed": "That time is already used",
     "badDate": "Select a day in the future",
+    "badTime": "Select time in the future",
     "validationTime": "Wrong time"
   },
   "select-options": {

--- a/apps/medon-fe/src/translation/en/translation.json
+++ b/apps/medon-fe/src/translation/en/translation.json
@@ -420,6 +420,7 @@
     "title": "Availability schedule:",
     "message": "Select day or availability slot to start editing",
     "timeUsed": "That time is already used",
+    "appointmentSet": "There is an appointment set on that time",
     "badDate": "Select a day in the future",
     "badTime": "Select time in the future",
     "validationTime": "Wrong time"


### PR DESCRIPTION
- changed settings to give opportunity to book availability for today
- removed possibility to remove/edit availability in the past
- removed possibility to remove/edit availability if appointment is booked to that time

**PR checklist:**

**1.1 Common**
- [x] 1.1.2 no any, should be also added to eslint rules
- [x] 1.1.1 types for input and output params
- [x] 1.1.3 try/catch for any async function
- [x] 1.1.4 no magic numbers
- [x] 1.1.5 compare only with constants not with strings (instead of user === ‘admin’, better user === roles.admin)
- [x] 1.1.6 no ternary operator inside ternary operator (bad example: question ? first: second ? third: fourth)
- [x] 1.1.7 avoid similar types with duplicating by generics
- [x] 1.1.8 no console.log in pr
- [x] 1.1.9 .env file should be in .gitignore
- [x] 1.1.10 delete commented code if it's not part of documentation
- [x] 1.1.11 no links in the code, env links should be in env file (for example: server url),
- [x] constant links (for example default avatar URL) should be in constant file
- [x] 1.1.12 constants and function names should be lowercase.
- [x] 1.1.13 no dates format in the code (like "dd/MM/yyyy”), move it in global constant variable
- [x] 1.1.14 import rules. imports should come in a specific order: node modules, absolute path, relative path
- [x] 1.1.15 strings should be in the constant variable. Example: instead of ‘15 3 * * *’, const EACH_DAY_15h_15min = ‘15 3 * * *’

 **1.3 Frontend|Mobile**
- [x] 1.3.1 split component and logic (move logic to custom hook file)
- [x] 1.3.2 colors, font size, and font name should be in the theme or in the constants
- [x] 1.3.3 no text in the components, use i18n approach, even if you have only one language for now
- [x] 1.3.4 inline styles prohibited
- [x] 1.3.5 import should be absolute. instead of ../../../components/myComponent should be components/myComponent
