### PR TITLE
MED-160-change-patient-note-pagination-to-load-more-show-15-notes

### DIFF
--- a/apps/medon-fe/src/components/PatientCardCalendar/index.tsx
+++ b/apps/medon-fe/src/components/PatientCardCalendar/index.tsx
@@ -24,6 +24,7 @@ import { getEventPropGetter } from 'utils/functions/getEventPropGetter';
 import {
   defaultLimit,
   defaultOrder,
+  defaultPage,
   maxLengthTextArea,
   roles,
   routes,
@@ -70,7 +71,7 @@ export function PatientCardCalendar() {
   const { role } = useAppSelector((state) => state.userState.user);
   const { t } = useTranslation();
   const [searchParams, setSearchParams] = useSearchParams();
-  const [page, setPage] = useState<number>(1);
+  const [page, setPage] = useState<number>(defaultPage);
   const order = searchParams.get('order') || defaultOrder;
   const theme = useTheme();
 

--- a/apps/medon-fe/src/components/PatientCardCalendar/index.tsx
+++ b/apps/medon-fe/src/components/PatientCardCalendar/index.tsx
@@ -112,7 +112,7 @@ export function PatientCardCalendar() {
   };
 
   useEffect(() => {
-    setPage(1);
+    setPage(defaultPage);
     setNotes([]);
   }, [text, order]);
 

--- a/apps/medon-fe/src/components/PatientNotes/index.tsx
+++ b/apps/medon-fe/src/components/PatientNotes/index.tsx
@@ -1,20 +1,25 @@
-import { Pagination, Skeleton } from 'antd';
+import { Skeleton } from 'antd';
 import { useTranslation } from 'react-i18next';
-import { useSearchParams } from 'react-router-dom';
 
 import PatientCardNotes from 'components/PatientCardNotes';
 import { PatientNote } from 'interfaces/patients';
 
 import { formatDate, formatTime } from 'utils/functions';
-import { defaultPage, defaultPageSize, pageSizeOptions } from 'utils/constants';
+import { defaultLimit } from 'utils/constants';
 
 import { IPatientNotesProps } from './types';
+import { BtnContainer, StyledButton } from './styles';
 
-export function PatientNotes({ notes, isFetching, total }: IPatientNotesProps) {
+export function PatientNotes({
+  notes = [],
+  isFetching,
+  total = 0,
+  page = 1,
+  setPage,
+}: IPatientNotesProps) {
   const { t } = useTranslation();
-  const [searchParams, setSearchParams] = useSearchParams();
 
-  if (isFetching) {
+  if (isFetching && !notes.length) {
     return <Skeleton active />;
   }
 
@@ -33,20 +38,19 @@ export function PatientNotes({ notes, isFetching, total }: IPatientNotesProps) {
           doctor={note.doctor}
         />
       ))}
-      <Pagination
-        total={total}
-        current={Number(searchParams.get('page')) || defaultPage}
-        pageSize={Number(searchParams.get('limit')) || defaultPageSize}
-        defaultCurrent={1}
-        onChange={(pageValue, pageSize) => {
-          setSearchParams({
-            page: pageValue.toString(),
-            limit: pageSize.toString(),
-          });
-        }}
-        showSizeChanger
-        pageSizeOptions={pageSizeOptions}
-      />
+      {total > page * defaultLimit && (
+        <BtnContainer>
+          <StyledButton
+            type="primary"
+            size="large"
+            onClick={() => {
+              setPage((prev) => prev + 1);
+            }}
+          >
+            {t('patient-list.load-more')}
+          </StyledButton>
+        </BtnContainer>
+      )}
     </>
   );
 }

--- a/apps/medon-fe/src/components/PatientNotes/index.tsx
+++ b/apps/medon-fe/src/components/PatientNotes/index.tsx
@@ -5,7 +5,7 @@ import PatientCardNotes from 'components/PatientCardNotes';
 import { PatientNote } from 'interfaces/patients';
 
 import { formatDate, formatTime } from 'utils/functions';
-import { defaultLimit } from 'utils/constants';
+import { defaultLimit, defaultPage } from 'utils/constants';
 
 import { IPatientNotesProps } from './types';
 import { BtnContainer, StyledButton } from './styles';
@@ -14,7 +14,7 @@ export function PatientNotes({
   notes = [],
   isFetching,
   total = 0,
-  page = 1,
+  page = defaultPage,
   setPage,
 }: IPatientNotesProps) {
   const { t } = useTranslation();

--- a/apps/medon-fe/src/components/PatientNotes/styles.ts
+++ b/apps/medon-fe/src/components/PatientNotes/styles.ts
@@ -1,0 +1,15 @@
+import { Button } from 'antd';
+import styled from 'styled-components';
+
+export const StyledButton = styled(Button)`
+  width: 200px;
+  background: ${({ theme }) => theme.colors.btnGradient} !important;
+  font-size: ${({ theme }) => theme.fontSizes.md} !important;
+  font-family: ${({ theme }) => theme.fontFamily.sf_pro_text} !important;
+`;
+
+export const BtnContainer = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: center;
+`;

--- a/apps/medon-fe/src/components/PatientNotes/types.ts
+++ b/apps/medon-fe/src/components/PatientNotes/types.ts
@@ -1,7 +1,10 @@
 import { PatientNote } from 'interfaces/patients';
+import { Dispatch, SetStateAction } from 'react';
 
 export interface IPatientNotesProps {
   notes: PatientNote[] | undefined;
   isFetching: boolean;
   total: number | undefined;
+  page: number;
+  setPage: Dispatch<SetStateAction<number>>;
 }

--- a/apps/medon-fe/src/components/Routes/PrivateRoute.tsx
+++ b/apps/medon-fe/src/components/Routes/PrivateRoute.tsx
@@ -8,13 +8,13 @@ import { getNotification } from 'redux/features/notificationSlice/notificationSl
 
 import Navigation from 'components/Navigation';
 import { Notification } from 'components/Notification';
+import { NotificationType, TimerType } from 'components/Notification/types';
 
 import { localDoctorRoutes, routes } from 'utils/constants/routes';
 import { roles } from 'utils/constants/roles';
 
 import { Container, Wrapper } from './styles';
 import { useNotification } from './hooks/useNotification';
-import { NotificationType, TimerType } from 'components/Notification/types';
 
 interface IProps {
   component: React.ReactElement;


### PR DESCRIPTION
- patient notes pagination changed to 15 per page and "load more"
- 
**PR checklist:**

**1.1 Common**
- [x] 1.1.2 no any, should be also added to eslint rules
- [x] 1.1.1 types for input and output params
- [x] 1.1.3 try/catch for any async function
- [x] 1.1.4 no magic numbers
- [x] 1.1.5 compare only with constants not with strings (instead of user === ‘admin’, better user === roles.admin)
- [x] 1.1.6 no ternary operator inside ternary operator (bad example: question ? first: second ? third: fourth)
- [x] 1.1.7 avoid similar types with duplicating by generics
- [x] 1.1.8 no console.log in pr
- [x] 1.1.9 .env file should be in .gitignore
- [x] 1.1.10 delete commented code if it's not part of documentation
- [x] 1.1.11 no links in the code, env links should be in env file (for example: server url),
- [x] constant links (for example default avatar URL) should be in constant file
- [x] 1.1.12 constants and function names should be lowercase.
- [x] 1.1.13 no dates format in the code (like "dd/MM/yyyy”), move it in global constant variable
- [x] 1.1.14 import rules. imports should come in a specific order: node modules, absolute path, relative path
- [x] 1.1.15 strings should be in the constant variable. Example: instead of ‘15 3 * * *’, const EACH_DAY_15h_15min = ‘15 3 * * *’

 **1.3 Frontend|Mobile**
- [x] 1.3.1 split component and logic (move logic to custom hook file)
- [x] 1.3.2 colors, font size, and font name should be in the theme or in the constants
- [x] 1.3.3 no text in the components, use i18n approach, even if you have only one language for now
- [x] 1.3.4 inline styles prohibited
- [x] 1.3.5 import should be absolute. instead of ../../../components/myComponent should be components/myComponent
